### PR TITLE
Intel compilers: add Intel's cmake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(slothmodel VERSION 1.0.0 DESCRIPTION "Simple Logical Tautology Handler (SLoTH) Model Shared Library")
 
+# https://www.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top/compiler-setup/use-the-command-line/use-cmake-with-the-compiler.html
+# Incidentally... MUST COME AFTER `project(...)`!
+if (INTEL_DPCPP)
+    #cmake_minimum_required(VERSION 3.20)
+    find_package(IntelDPCPP REQUIRED)
+endif()
+
 if(WIN32)
     add_library(slothmodel src/sloth.cpp)
 else()


### PR DESCRIPTION
Intel compilers: add Intel's cmake module

## Additions

-Intel compilers: add Intel's cmake module

## Removals

-

## Changes

-

## Testing

1. Compiled and tested with OneAPI 2022.3

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [X] Linux

